### PR TITLE
NGI - Updating licensing aspects according to REUSE

### DIFF
--- a/1.hw/csi_rx/csi_rx_align_byte.sv
+++ b/1.hw/csi_rx/csi_rx_align_byte.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/csi_rx/csi_rx_align_word.sv
+++ b/1.hw/csi_rx/csi_rx_align_word.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/csi_rx/csi_rx_clk_det.sv
+++ b/1.hw/csi_rx/csi_rx_clk_det.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/csi_rx/csi_rx_hdr_ecc.sv
+++ b/1.hw/csi_rx/csi_rx_hdr_ecc.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/csi_rx/csi_rx_packer_handler.sv
+++ b/1.hw/csi_rx/csi_rx_packer_handler.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/csi_rx/csi_rx_phy_clk.sv
+++ b/1.hw/csi_rx/csi_rx_phy_clk.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/csi_rx/csi_rx_phy_dat.sv
+++ b/1.hw/csi_rx/csi_rx_phy_dat.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/csi_rx/csi_rx_top.sv
+++ b/1.hw/csi_rx/csi_rx_top.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/isp/isp_top.sv
+++ b/1.hw/isp/isp_top.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/isp/raw2rgb.sv
+++ b/1.hw/isp/raw2rgb.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/lib/fpgatech/XILINX/fpga_olvds.sv
+++ b/1.hw/lib/fpgatech/XILINX/fpga_olvds.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //========================================================================
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/lib/fpgatech/XILINX/fpga_oser10.sv
+++ b/1.hw/lib/fpgatech/XILINX/fpga_oser10.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //========================================================================
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/lib/fpgatech/XILINX/fpga_pll_hdmi.sv
+++ b/1.hw/lib/fpgatech/XILINX/fpga_pll_hdmi.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/lib/fpgatech/XILINX/fpga_pll_top.sv
+++ b/1.hw/lib/fpgatech/XILINX/fpga_pll_top.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/misc/clkrst_gen.sv
+++ b/1.hw/misc/clkrst_gen.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/misc/rgb2hdmi.sv
+++ b/1.hw/misc/rgb2hdmi.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/top.sv
+++ b/1.hw/top.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/1.hw/top_pkg.sv
+++ b/1.hw/top_pkg.sv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 //======================================================================== 
 // openeye-CamSI * NLnet-sponsored open-source core for Camera I/F with ISP
 //------------------------------------------------------------------------

--- a/2.sim/cocotb/top/Makefile
+++ b/2.sim/cocotb/top/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Robert Metchev
+#
+# SPDX-License-Identifier: CERN-OHL-P-2.0
+
 #
 # Authored by: Robert Metchev / Chips & Scripts (rmetchev@ieee.org)
 #

--- a/2.sim/cocotb/top/fpga_pll.py
+++ b/2.sim/cocotb/top/fpga_pll.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import ClockCycles, RisingEdge, FallingEdge, Timer, with_timeout

--- a/2.sim/cocotb/top/test_top.py
+++ b/2.sim/cocotb/top/test_top.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Chili.CHIPS*ba
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer, FallingEdge

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/CERN-OHL-P-2.0.txt
+++ b/LICENSES/CERN-OHL-P-2.0.txt
@@ -1,0 +1,199 @@
+CERN Open Hardware Licence Version 2 - Permissive
+
+
+Preamble
+
+CERN has developed this licence to promote collaboration among
+hardware designers and to provide a legal tool which supports the
+freedom to use, study, modify, share and distribute hardware designs
+and products based on those designs. Version 2 of the CERN Open
+Hardware Licence comes in three variants: this licence, CERN-OHL-P
+(permissive); and two reciprocal licences: CERN- OHL-W (weakly
+reciprocal) and CERN-OHL-S (strongly reciprocal).
+
+The CERN-OHL-P is copyright CERN 2020. Anyone is welcome to use it, in
+unmodified form only.
+
+Use of this Licence does not imply any endorsement by CERN of any
+Licensor or their designs nor does it imply any involvement by CERN in
+their development.
+
+
+1 Definitions
+
+  1.1 'Licence' means this CERN-OHL-P.
+
+  1.2 'Source' means information such as design materials or digital
+      code which can be applied to Make or test a Product or to
+      prepare a Product for use, Conveyance or sale, regardless of its
+      medium or how it is expressed. It may include Notices.
+
+  1.3 'Covered Source' means Source that is explicitly made available
+      under this Licence.
+
+  1.4 'Product' means any device, component, work or physical object,
+      whether in finished or intermediate form, arising from the use,
+      application or processing of Covered Source.
+
+  1.5 'Make' means to create or configure something, whether by
+     manufacture, assembly, compiling, loading or applying Covered
+     Source or another Product or otherwise.
+
+  1.6 'Notice' means copyright, acknowledgement and trademark notices,
+      references to the location of any Notices, modification notices
+      (subsection 3.3(b)) and all notices that refer to this Licence
+      and to the disclaimer of warranties that are included in the
+      Covered Source.
+
+  1.7 'Licensee' or 'You' means any person exercising rights under
+      this Licence.
+
+  1.8 'Licensor' means a person who creates Source or modifies Covered
+      Source and subsequently Conveys the resulting Covered Source
+      under the terms and conditions of this Licence. A person may be
+      a Licensee and a Licensor at the same time.
+
+  1.9 'Convey' means to communicate to the public or distribute.
+
+
+2 Applicability
+
+  2.1 This Licence governs the use, copying, modification, Conveying
+      of Covered Source and Products, and the Making of Products. By
+      exercising any right granted under this Licence, You irrevocably
+      accept these terms and conditions.
+
+  2.2 This Licence is granted by the Licensor directly to You, and
+      shall apply worldwide and without limitation in time.
+
+  2.3 You shall not attempt to restrict by contract or otherwise the
+      rights granted under this Licence to other Licensees.
+
+  2.4 This Licence is not intended to restrict fair use, fair dealing,
+      or any other similar right.
+
+
+3 Copying, modifying and Conveying Covered Source
+
+  3.1 You may copy and Convey verbatim copies of Covered Source, in
+      any medium, provided You retain all Notices.
+
+  3.2 You may modify Covered Source, other than Notices.
+
+      You may only delete Notices if they are no longer applicable to
+      the corresponding Covered Source as modified by You and You may
+      add additional Notices applicable to Your modifications.
+
+  3.3 You may Convey modified Covered Source (with the effect that You
+      shall also become a Licensor) provided that You:
+
+       a) retain Notices as required in subsection 3.2; and
+
+       b) add a Notice to the modified Covered Source stating that You
+          have modified it, with the date and brief description of how
+          You have modified it.
+
+  3.4 You may Convey Covered Source or modified Covered Source under
+      licence terms which differ from the terms of this Licence
+      provided that:
+
+       a) You comply at all times with subsection 3.3; and
+
+       b) You provide a copy of this Licence to anyone to whom You
+          Convey Covered Source or modified Covered Source.
+
+
+4 Making and Conveying Products
+
+You may Make Products, and/or Convey them, provided that You ensure
+that the recipient of the Product has access to any Notices applicable
+to the Product.
+
+
+5 DISCLAIMER AND LIABILITY
+
+  5.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products
+      are provided 'as is' and any express or implied warranties,
+      including, but not limited to, implied warranties of
+      merchantability, of satisfactory quality, non-infringement of
+      third party rights, and fitness for a particular purpose or use
+      are disclaimed in respect of any Source or Product to the
+      maximum extent permitted by law. The Licensor makes no
+      representation that any Source or Product does not or will not
+      infringe any patent, copyright, trade secret or other
+      proprietary right. The entire risk as to the use, quality, and
+      performance of any Source or Product shall be with You and not
+      the Licensor. This disclaimer of warranty is an essential part
+      of this Licence and a condition for the grant of any rights
+      granted under this Licence.
+
+  5.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to
+      the maximum extent permitted by law, have no liability for
+      direct, indirect, special, incidental, consequential, exemplary,
+      punitive or other damages of any character including, without
+      limitation, procurement of substitute goods or services, loss of
+      use, data or profits, or business interruption, however caused
+      and on any theory of contract, warranty, tort (including
+      negligence), product liability or otherwise, arising in any way
+      in relation to the Covered Source, modified Covered Source
+      and/or the Making or Conveyance of a Product, even if advised of
+      the possibility of such damages, and You shall hold the
+      Licensor(s) free and harmless from any liability, costs,
+      damages, fees and expenses, including claims by third parties,
+      in relation to such use.
+
+
+6 Patents
+
+  6.1 Subject to the terms and conditions of this Licence, each
+      Licensor hereby grants to You a perpetual, worldwide,
+      non-exclusive, no-charge, royalty-free, irrevocable (except as
+      stated in this section 6, or where terminated by the Licensor
+      for cause) patent license to Make, have Made, use, offer to
+      sell, sell, import, and otherwise transfer the Covered Source
+      and Products, where such licence applies only to those patent
+      claims licensable by such Licensor that are necessarily
+      infringed by exercising rights under the Covered Source as
+      Conveyed by that Licensor.
+
+  6.2 If You institute patent litigation against any entity (including
+      a cross-claim or counterclaim in a lawsuit) alleging that the
+      Covered Source or a Product constitutes direct or contributory
+      patent infringement, or You seek any declaration that a patent
+      licensed to You under this Licence is invalid or unenforceable
+      then any rights granted to You under this Licence shall
+      terminate as of the date such process is initiated.
+
+
+7 General
+
+  7.1 If any provisions of this Licence are or subsequently become
+      invalid or unenforceable for any reason, the remaining
+      provisions shall remain effective.
+
+  7.2 You shall not use any of the name (including acronyms and
+      abbreviations), image, or logo by which the Licensor or CERN is
+      known, except where needed to comply with section 3, or where
+      the use is otherwise allowed by law. Any such permitted use
+      shall be factual and shall not be made so as to suggest any kind
+      of endorsement or implication of involvement by the Licensor or
+      its personnel.
+
+  7.3 CERN may publish updated versions and variants of this Licence
+      which it considers to be in the spirit of this version, but may
+      differ in detail to address new problems or concerns. New
+      versions will be published with a unique version number and a
+      variant identifier specifying the variant. If the Licensor has
+      specified that a given variant applies to the Covered Source
+      without specifying a version, You may treat that Covered Source
+      as being released under any version of the CERN-OHL with that
+      variant. If no variant is specified, the Covered Source shall be
+      treated as being released under CERN-OHL-S. The Licensor may
+      also specify that the Covered Source is subject to a specific
+      version of the CERN-OHL or any later version in which case You
+      may apply this or any later version of CERN-OHL with the same
+      variant identifier published by CERN.
+
+  7.4 This Licence shall not be enforceable except by a Licensor
+      acting as such, and third party beneficiary rights are
+      specifically excluded.


### PR DESCRIPTION
Hello,

Following up on our previous email, we have been working with the NGI framework, helping projects with their licensing and copyright management. After a quick check on your repository, I would like to propose some updates regarding copyright and licensing information. The principles of REUSE would still apply to your open hardware project. However, since we mainly deal with Free Software projects, we've decided to provide this pull request just as a guideline of how you can further make more clear your legal information display. 

 [REUSE](https://reuse.software/) is an FSFE-developed initiative intended to make licensing easier by establishing a single way to display all copyright and licensing information through comment headers on source files that can be human- and machine-readable.



# REUSE Features:

### Copyright and Licensing Information in each file

One of the main features of REUSE is that each file in the repository contains copyright and license information with the help of a comment header that is human- and machine-readable. This has already been done in some of the files in your repo, for example, the files in the `/1.hw/isp/ `folder. What I did was include the machine-readable headers with the help of the reuse tool. I also decided to use the argument` --no-replace` to [preserve existing headers ](https://reuse.readthedocs.io/en/stable/usage.html#annotate).

As stated, I was able to add headers to some files of certain directories. However, as this serves as a guideline, I did not do so for all of them. I didn't touch directories such as `0.doc/`, since it has quite some documentation files and image files for which the license and copyright information is not clear. Please note that REUSE has also an option to add this information for [binary and uncommentable files](https://reuse.software/tutorial/#binary-and-uncommentable-files), as well as for [insignificant files ](https://reuse.software/tutorial/#insignificant-files)- no copyrightable files such as  `.gitignore`.

### LICENSES directory in the root of the project with the licenses used on the repository:

I included in this directory the files with the texts of the 3-Clause BSD License and the CERN Open Hardware Licence Version 2 - Permissive (used in some files). Please feel free to correct this information and adapt the rest of the files according to the correct license and copyright information. In case of other existing licenses, please do not forget to include the text of such in the `LICENSES/` folder.

### Files missing copyright and licensing information:

Please feel free to check the [REUSE documentation](https://reuse.readthedocs.io/en/stable/) and the [helper tool ](https://reuse.software/dev/#tool), and if you are interested in making your project REUSE compliant, please add the legal information to the missing files. I am also available if you want support with the process.

Please also double-check if the personal information in the headers is correct and consistent, in the case of several copyright holders please update that information in the headers. In case you want to license certain files under a different license, special attention should also be paid to that aspect and such files should contain the appropriate SPDX tag.

## Wide range of tools

In case you find REUSE useful, we offer other tools to help you continuously check and display compliance with the REUSE guidelines. For instance, you can automatically run reuse lint on every commit as[ a pre-commit hook](https://reuse.software/dev/#pre-commit-hook) for Git. And, it can be easily [integrated into your existing CI/CD processes](https://reuse.software/dev/#ci) to continuously test your repository and its changes for REUSE compliance.

As my colleague Gabriel mentioned, we are more than happy to go through the specifics of REUSE in a call if you find this convenient, however, I would highly recommend checking all our documentation and tutorial.

Thank you very much for the amazing job!